### PR TITLE
bmp085: use different i2c bus if Grove sensor

### DIFF
--- a/Support/BoneScript/demo_bmp085/index.html
+++ b/Support/BoneScript/demo_bmp085/index.html
@@ -42,12 +42,10 @@ var bus = 1;
 // uncomment if using SeeedStudio Grove sensor
 // bus = 2;
 var iic = '/sys/class/i2c-adapter/i2c-' + bus + '/';
-var temperature = '/sys/bus/i2c/drivers/bmp085/' + bus + '-0077/temp0_input';
-var pressure = '/sys/bus/i2c/drivers/bmp085/' + bus + '-0077/pressure0_input';
 
 //Sensor Locations on the BeagleBone Black
-var temperature = '/sys/bus/i2c/drivers/bmp085/1-0077/temp0_input';
-var pressure = '/sys/bus/i2c/drivers/bmp085/1-0077/pressure0_input';
+var temperature = '/sys/bus/i2c/drivers/bmp085/' + bus + '-0077/temp0_input';
+var pressure = '/sys/bus/i2c/drivers/bmp085/' + bus + '-0077/pressure0_input';
 
 // We will initialize the driver for the BMP085 sensor located at I2C location 0x77
 b.writeTextFile(iic + 'new_device', 'bmp085 0x77');

--- a/Support/BoneScript/demo_bmp085/index.html
+++ b/Support/BoneScript/demo_bmp085/index.html
@@ -38,7 +38,12 @@ kernel, so all you have to do is ask the kernel to load the driver and then star
 </h2>
 <pre id="code" class="use-editor" style="height:425px;">
 var b = require('bonescript');
-var iic = '/sys/class/i2c-adapter/i2c-1/'; 
+var bus = 1;
+// uncomment if using SeeedStudio Grove sensor
+// bus = 2;
+var iic = '/sys/class/i2c-adapter/i2c-' + bus + '/';
+var temperature = '/sys/bus/i2c/drivers/bmp085/' + bus + '-0077/temp0_input';
+var pressure = '/sys/bus/i2c/drivers/bmp085/' + bus + '-0077/pressure0_input';
 
 //Sensor Locations on the BeagleBone Black
 var temperature = '/sys/bus/i2c/drivers/bmp085/1-0077/temp0_input';


### PR DESCRIPTION
Users with SeeedStudio Grove module should use the second i2c bus.

TODO: automatically try i2c bus 2 if 0x77 sensor is not found on i2c bus 1